### PR TITLE
Add toy transformer example

### DIFF
--- a/src/bin/mini_transformer.rs
+++ b/src/bin/mini_transformer.rs
@@ -1,0 +1,38 @@
+use garbled_neural_net_experiments::transformer::*;
+use fancy_garbling::twopac::semihonest::{Garbler, Evaluator};
+use fancy_garbling::Fancy;
+use fancy_garbling::FancyInput;
+use ocelot::ot::{AlszReceiver as OtReceiver, AlszSender as OtSender};
+use scuttlebutt::{unix_channel_pair, AesRng, UnixChannel};
+use std::io::{self, Read};
+
+fn main() {
+    // Create a Unix channel pair
+    let (sender, receiver) = unix_channel_pair();
+
+    // Spawn evaluator thread
+    std::thread::spawn(move || {
+        let rng = AesRng::new();
+        let mut ev = Evaluator::<UnixChannel, AesRng, OtReceiver>::new(receiver, rng).unwrap();
+        // Read evaluator input from stdin as whitespace-separated numbers
+        let mut input_str = String::new();
+        io::stdin().read_to_string(&mut input_str).unwrap();
+        let x_plain: Vec<u16> = input_str
+            .split_whitespace()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+        let moduli = vec![1 << 15; x_plain.len()];
+        let x_wires = ev.encode_many(&x_plain, &moduli).unwrap();
+        let params = Params::load();
+        let out = mini_transformer(&mut ev, &x_wires, &params);
+        let res: Vec<u16> = out.iter().map(|w| ev.output(w).unwrap().unwrap()).collect();
+        println!("{:?}", res);
+    });
+
+    // Garbler side
+    let rng = AesRng::new();
+    let mut gb = Garbler::<UnixChannel, AesRng, OtSender>::new(sender, rng).unwrap();
+    let params = Params::load();
+    let dummy_x = vec![gb.constant(0, 1 << 15).unwrap(); params.d_model];
+    mini_transformer(&mut gb, &dummy_x, &params);
+}

--- a/src/gc_layers.rs
+++ b/src/gc_layers.rs
@@ -1,0 +1,35 @@
+use fancy_garbling::{Fancy, HasModulus};
+
+/// Encode a public 16-bit constant vector into GC wires
+pub fn const_vec<F: Fancy>(f: &mut F, v: &[u16]) -> Vec<F::Item> {
+    v.iter().map(|&c| f.constant(c, 1 << 15).unwrap()).collect()
+}
+
+/// One matrix-vector multiply with public W (shape m×n) and secret x (len n)
+pub fn matvec<F: Fancy>(
+    f: &mut F,
+    w: &[Vec<u16>],    // rows
+    x: &[F::Item],
+) -> Vec<F::Item> {
+    w.iter().map(|row| {
+        let mut acc = f.constant(0, 1 << 15).unwrap();
+        for (&w_ij, x_j) in row.iter().zip(x) {
+            let prod = f.cmul(x_j, w_ij).unwrap();   // 1 HG
+            acc = f.add(&acc, &prod).unwrap();
+        }
+        acc
+    }).collect()
+}
+
+/// ReLU(x) = max(x,0) using Ball-Rosulek 1-AND comparator
+pub fn relu<F: Fancy>(f: &mut F, x: F::Item) -> F::Item {
+    let is_pos = gt_const(f, &x, 0);
+    f.mul(&is_pos, &x).unwrap()
+}
+
+/// Compare `x` against a constant `c`, returning 1 if `x > c` else 0.
+pub fn gt_const<F: Fancy>(f: &mut F, x: &F::Item, c: u16) -> F::Item {
+    let q = x.modulus();
+    let tt: Vec<u16> = (0..q).map(|v| if v > c { 1 } else { 0 }).collect();
+    f.proj(x, 2, Some(tt)).unwrap()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod gc_layers;
+pub mod transformer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(atomic_min_max)]
 
 pub mod direct_tests;
 pub mod dummy_tests;

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -1,0 +1,69 @@
+use crate::gc_layers::{matvec, relu, gt_const};
+use fancy_garbling::Fancy;
+
+/// Holder for quantized Transformer weights.
+#[derive(Clone)]
+pub struct Params {
+    pub w_q: Vec<Vec<u16>>, // (d_model x d_model)
+    pub w_k: Vec<Vec<u16>>, // (d_model x d_model)
+    pub w_v: Vec<Vec<u16>>, // (d_model x d_model)
+    pub w_ff1: Vec<Vec<u16>>,
+    pub w_ff2: Vec<Vec<u16>>,
+    pub scale: u16,
+    pub thresh: u16,
+    pub d_model: usize,
+}
+
+impl Params {
+    /// Load parameters from disk. Here we simply generate dummy values
+    /// to keep the example self contained.
+    pub fn load() -> Self {
+        // small demo with d_model=4
+        let d = 4;
+        let dummy = vec![vec![1u16; d]; d];
+        Self {
+            w_q: dummy.clone(),
+            w_k: dummy.clone(),
+            w_v: dummy.clone(),
+            w_ff1: dummy.clone(),
+            w_ff2: dummy.clone(),
+            scale: 1,
+            thresh: 0,
+            d_model: d,
+        }
+    }
+}
+
+/// A single-layer encoder block.
+pub fn mini_transformer<F: Fancy>(
+    f: &mut F,
+    x: &[F::Item],
+    params: &Params,
+) -> Vec<F::Item> {
+    // 1) Q = W_Q x ;  K = W_K x ; V = W_V x
+    let q = matvec(f, &params.w_q, x);
+    let k = matvec(f, &params.w_k, x);
+    let v = matvec(f, &params.w_v, x);
+
+    // 2) score = (Q·K) * scale
+    let mut score = f.constant(0, 1 << 15).unwrap();
+    for (q_i, k_i) in q.iter().zip(&k) {
+        let prod = f.mul(q_i, k_i).unwrap();
+        score = f.add(&score, &prod).unwrap();
+    }
+    score = f.cmul(&score, params.scale).unwrap();
+    // Demo shortcut: treat score as gate
+    let gate = gt_const(f, &score, params.thresh);
+    // 3) context = gate * V
+    let context: Vec<_> = v
+        .iter()
+        .map(|v_i| f.mul(&gate, v_i).unwrap())
+        .collect();
+
+    // 4) FFN: y = W2 · ReLU(W1·context)
+    let z1 = matvec(f, &params.w_ff1, &context)
+        .into_iter()
+        .map(|w| relu(f, w))
+        .collect::<Vec<_>>();
+    matvec(f, &params.w_ff2, &z1)
+}


### PR DESCRIPTION
## Summary
- add helper GC layers implementing matvec, ReLU and comparisons
- implement minimal Transformer encoder using these helpers
- expose new modules via `lib.rs`
- add a `mini_transformer` binary demonstrating two-party evaluation
- remove obsolete feature gate from `main.rs`

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68480e567aa0832cbfaa8f60bea65417